### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities dictionary
- Description mentions the GitHub Certifications program
- Schedule: Mondays and Thursdays, 3:30 PM - 5:00 PM
- Max participants: 25
- Ready for student registrations

## Issue
Closes #6

## Context
This activity was announced in the school assembly as part of a partnership with GitHub to teach students practical coding and collaboration skills. The GitHub Certifications program will help students with their college applications. Registration closes by the end of this week, so this is time-sensitive.

## Testing
- [x] Python syntax validated
- [x] Activity structure matches existing activities
- [x] Ready for immediate student signups